### PR TITLE
Add global BufstopGetBufferInfo function

### DIFF
--- a/plugin/bufstop.vim
+++ b/plugin/bufstop.vim
@@ -145,6 +145,14 @@ function! s:MapKeys()
   endfor
 endfunction
 
+function! BufstopGetBufferInfo()
+    redir => s:lsoutput
+    exe "silent ls"
+    redir END
+
+    return s:GetBufferInfo()
+endfunction
+
 " parse buffer list and get relevant info
 function! s:GetBufferInfo()
   let s:allbufs = []


### PR DESCRIPTION
I'm writing a plugin (https://github.com/bentomas/bufstop_tabline) that needs access to the bufstop buffer info, so this commit adds a global function to get it.
